### PR TITLE
Include the summary image as an attachment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,7 @@ The Albion Guildbot can be set up with either environment variables or directly
 modifying `config.js`. The bot was developed against a Heroku environment,
 where environment variables are preferred.
 
-### Step 1 - Set up a Google Storage account
-You'll need a Google Storage account to host the generated image files to be
-used in the bot's individual kill posts. Once you have a project created,
-use the values of `serviceAccountKey.json` to either fill in `config.js`
-directly or set your environment's env vars as specified in `config.js`.
-
-### Step 2 - Create a Discord bot
+### Step 1 - Create a Discord bot
 Using the Discord dev console, set up a Discord bot and add it to your
 server. You will need the bot's token (found on discord dev console) and
 the channelID of the channel you want it to post to (found by right clicking
@@ -34,19 +28,19 @@ the channel in Discord after enabling developer mode in Discord settings). Add
 these settings either to your `config.js` directly, or set the appropriate
 env vars in your environment according to `config.js`.
 
-### Step 3 - Install Redis
+### Step 2 - Install Redis
 This project uses Redis to persist data. If deploying through heroku, just
 install the "Redis Heroku" addon. For local development, redis will need
 to be installed locally and run as a service.
 
-### Step 4 - Configure to your guild
+### Step 3 - Configure to your guild
 Set your alliance and guild name(s) in `config.js` or the corresponding
 environment variables. If set by Environment variable, guilds should be
 set as a comma-separated string. For example, `ALBION_GUILDS="TeamCasualty,Team Casualty 2"`
 
-### Step 5 - Push to your environment or run locally
+### Step 4 - Push to your environment or run locally
 
-#### 5a. Environment example: Heroku
+#### 4a. Environment example: Heroku
 Using heroku, you should already have a Heroku project set up (it will need to
 be paid if you plan to run the bot 24/7). You should have your heroku repository
 set as a git source (eg `git remote add heroku https://your.heroku.repo`).
@@ -57,7 +51,7 @@ Heroku CLI, the project can be pushed to heroku via git, eg `git push heroku mas
 If using heroku, make sure to also set the environment variable HEROKU to true. If you
 don't, heroku will shut down after not being bound to a port for 60 seconds.
 
-#### 5b. Running locally
+#### 4b. Running locally
 To run locally, first you'll need to install the dependencies via npm
 ```
 npm install

--- a/config.js
+++ b/config.js
@@ -13,26 +13,5 @@ module.exports = {
       ? process.env.ALBION_GUILDS.split(',') : [],
     // The Discord token of the Bot to post through.
     token: process.env.DISCORD_TOKEN,
-  },
-  /**
-   * Google storage settings. These are used to post images to a google
-   *   storage account to be linked to from Discord. These values come
-   *   straight from the serviceAccountKey.json file that is generated
-   *   for a Google Storage project.
-   */
-  googleStorage: {
-    // Required
-    client_email: process.env.GOOGLE_CLIENT_EMAIL,
-    client_id: process.env.GOOGLE_CLIENT_ID,
-    client_x509_cert_url: process.env.GOOGLE_CLIENT_X509_CERT_URL,
-    project_id: process.env.GOOGLE_PROJECT_ID,
-    private_key: process.env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n'),
-    private_key_id: process.env.GOOGLE_PRIVATE_KEY_ID,
-
-    // Should be OK to default
-    auth_provider_x509_cert_url: process.env.GOOGLE_AUTH_PROVIDER_X509_CERT_URL || 'https://www.googleapis.com/oauth2/v1/certs',
-    auth_uri: process.env.GOOGLE_AUTH_URI || 'https://accounts.google.com/o/oauth2/auth',
-    token_uri: process.env.GOOGLE_TOKEN_URI || 'https://accounts.google.com/o/oauth2/token',
-    type: process.env.GOOGLE_TYPE || 'service_account',
-  },
+  }
 };

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
     "node": "8.4.0"
   },
   "dependencies": {
-    "@google-cloud/storage": "^1.2.1",
     "albion-api": "^1.3.0",
     "bluebird": "^3.5.0",
-    "discord.io": "^2.5.1",
+    "discord.js": "^11.2.1",
     "express": "^4.15.4",
     "jimp": "^0.2.28",
     "redis": "^2.8.0",

--- a/src/createImage.js
+++ b/src/createImage.js
@@ -1,14 +1,4 @@
-const googleStorage = require('@google-cloud/storage');
 const Jimp = require('jimp');
-
-const credentials = require('../config').googleStorage;
-
-const storage = googleStorage({
-  projectId: credentials.project_id,
-  credentials,
-});
-
-const bucket = storage.bucket('albion-images');
 
 const FONT_SIZE = 32;
 const ITEM_SIZE = 60;
@@ -108,24 +98,7 @@ function createImage(target, event) {
       return new Promise((resolve, reject) => {
         output.getBuffer(Jimp.MIME_PNG, (err, buffer) => {
           if (err) { return reject(err); }
-
-          const fileUpload = bucket.file(`${event.EventId}.png`);
-          const blobStream = fileUpload.createWriteStream({
-            metadata: { contentType: Jimp.MIME_PNG }
-          });
-
-          blobStream.on('error', (error) => {
-            console.error(error);
-            reject(error);
-          });
-
-          blobStream.on('finish', () => {
-            // The public URL can be used to directly access the file via HTTP.
-            const url = `https://storage.googleapis.com/${bucket.name}/${fileUpload.name}?a=${Math.random().toString(36)}`;
-            resolve(url);
-          });
-
-          blobStream.end(buffer);
+          resolve(buffer);
         });
       });
     });

--- a/src/index.js
+++ b/src/index.js
@@ -143,9 +143,9 @@ function sendBattleReport(battle, channelId) {
     fields,
   };
 
-  bot.channels.get(channelId || config.feedChannelId).send(`Battle: ${title}`, { embed }).then((_) => {
+  bot.channels.get(channelId || config.feedChannelId).send({ embed }).then(() => {
     logger.info(`Successfully posted log of battle between ${title}.`);
-  }).catch((err) => {
+  }).catch(err => {
     logger.error(err);
   });
 }
@@ -181,14 +181,14 @@ function sendKillReport(event, channelId) {
       });
     }
 
-    const files = [{ name: 'kill.png', attachment: imgBuffer }]
+    const files = [{ name: 'kill.png', attachment: imgBuffer }];
 
-    bot.channels.get((channelId || config.feedChannelId)).send(`${createDisplayName(event.Killer)} killing ${createDisplayName(event.Victim)}`, { embed, files }).then((_) => {
+    bot.channels.get((channelId || config.feedChannelId)).send({ embed, files }).then(() => {
 	logger.info(`Successfully posted log of ${createDisplayName(event.Killer)} killing ${createDisplayName(event.Victim)}.`);
-    }).catch((err) => {
+    }).catch(err => {
       logger.error(err)
     });
-  }).catch((err) => {
+  }).catch(err => {
       logger.error(err)
   });
 }
@@ -196,7 +196,6 @@ function sendKillReport(event, channelId) {
 function checkKillboard() {
   logger.info('Checking killboard...');
   Albion.getEvents({ limit: 51, offset: 0 }).then(events => {
-
     if (!events) { return; }
 
     events.filter(event => event.EventId > lastEventId).forEach(event => {
@@ -228,8 +227,8 @@ function createDisplayName(player) {
 }
 
 bot.on('message', msg => {
-  let message = msg.content
-  let channelID = msg.channel.id
+  let message = msg.content;
+  let channelID = msg.channel.id;
 
   let matches = message.match(/^https:\/\/albiononline\.com\/en\/killboard\/kill\/(\d+)/);
   if (matches && matches.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const bluebird = require('bluebird');
-const Discord = require('discord.io');
+const Discord = require('discord.js');
 const fs = require('fs');
 const logger = require('winston');
 const Redis = require('redis');
@@ -39,14 +39,11 @@ const databasePromise = Promise.all([
 ]);
 
 // Initialize Discord Bot
-const bot = new Discord.Client({
-  token: config.token,
-  autorun: true
-});
+const bot = new Discord.Client();
 
 bot.on('ready', () => {
   logger.info('Connected');
-  logger.info(`Logged in as: ${bot.username} - (${bot.id})`);
+  logger.info(`Logged in as: ${bot.user.username} - (${bot.user.id})`);
 
   databasePromise.then(() => {
     checkBattles();
@@ -146,16 +143,17 @@ function sendBattleReport(battle, channelId) {
     fields,
   };
 
-  bot.sendMessage({ to: channelId || config.feedChannelId, embed }, (err) => {
-    if (err) { return logger.error(err); }
+  bot.channels.get(channelId || config.feedChannelId).send(`Battle: ${title}`, { embed }).then((_) => {
     logger.info(`Successfully posted log of battle between ${title}.`);
+  }).catch((err) => {
+    logger.error(err);
   });
 }
 
 function sendKillReport(event, channelId) {
   const isFriendlyKill = config.guilds.indexOf(event.Killer.GuildName) !== -1;
 
-  createImage('Victim', event).then(imgUrl => {
+  createImage('Victim', event).then(imgBuffer => {
     const participants = parseInt(event.numberOfParticipants || event.GroupMembers.length, 10);
     const assists = participants - 1;
 
@@ -164,7 +162,7 @@ function sendKillReport(event, channelId) {
       title: `${event.Killer.Name} (${assists ? '+' + assists : 'Solo!'}) just killed ${event.Victim.Name}!`,
       description: `From guild: ${createGuildTag(event[isFriendlyKill ? 'Victim' : 'Killer'])}`,
       color: isFriendlyKill ? 65280 : 16711680,
-      image: { url: imgUrl },
+      image: { url: 'attachment://kill.png' },
     };
 
     if (event.TotalVictimKillFame > 25000) {
@@ -183,16 +181,22 @@ function sendKillReport(event, channelId) {
       });
     }
 
-    bot.sendMessage({ to: channelId || config.feedChannelId, embed }, (err) => {
-      if (err) { return logger.error(err); }
-      logger.info(`Successfully posted log of ${createDisplayName(event.Killer)} killing ${createDisplayName(event.Victim)}.`);
+    const files = [{ name: 'kill.png', attachment: imgBuffer }]
+
+    bot.channels.get((channelId || config.feedChannelId)).send(`${createDisplayName(event.Killer)} killing ${createDisplayName(event.Victim)}`, { embed, files }).then((_) => {
+	logger.info(`Successfully posted log of ${createDisplayName(event.Killer)} killing ${createDisplayName(event.Victim)}.`);
+    }).catch((err) => {
+      logger.error(err)
     });
+  }).catch((err) => {
+      logger.error(err)
   });
 }
 
 function checkKillboard() {
   logger.info('Checking killboard...');
   Albion.getEvents({ limit: 51, offset: 0 }).then(events => {
+
     if (!events) { return; }
 
     events.filter(event => event.EventId > lastEventId).forEach(event => {
@@ -223,7 +227,10 @@ function createDisplayName(player) {
   return `**<${allianceTag}${player.GuildName || 'Unguilded'}>** ${player.Name}`;
 }
 
-bot.on('message', (user, userID, channelID, message) => {
+bot.on('message', msg => {
+  let message = msg.content
+  let channelID = msg.channel.id
+
   let matches = message.match(/^https:\/\/albiononline\.com\/en\/killboard\/kill\/(\d+)/);
   if (matches && matches.length) {
     Albion.getEvent(matches[1]).then(event => {
@@ -264,3 +271,5 @@ bot.on('message', (user, userID, channelID, message) => {
       break;
   }
 });
+
+bot.login(config.token);


### PR DESCRIPTION
Hi,

This patch removes the Google Cloud storage requirement and has the embed pull the [image from an attachment](https://discordapp.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds). This makes the bot simpler to host, eliminating another service which the installer needs to contend with. To accomplish this I had to convert the bot from using `discord.io` to `discord.js`, since discord.io does not support attachments and embeds in the same message. 

Thanks,
Hunter