### PR TITLE
Catch if JSON response is broken

### DIFF
--- a/src/AlbionApi.ts
+++ b/src/AlbionApi.ts
@@ -21,7 +21,11 @@ function baseRequest(path: string, queries?: { [key: string]: any }): Promise<an
         reject(error || response);
         return;
       }
-      resolve(JSON.parse(body));
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(error);
+      }
     });
   });
 }


### PR DESCRIPTION
Sometimes the Albion Online server give us an invalid/broken JSON response. I got this 2 times in a few days now. So let's catch this.

```
info: Checking killboard...
undefined:1
[{"id":10338077,"startTime":"2017-10-31T19:05:36.329987300Z","endTime":"2017-10-31T19:12:03.758906200Z","timeout":"2017-10-31T19:15:03.758906200Z","totalFame":186371,"totalKills":22,"clusterName":null,"players":{"V-KEMTOwSGu4kIPI9voihA":{"id":"V-KEMTOwSGu4kIPI9voihA","name":"UberChio","kills":0,"deaths":3,"killFame":0,"guildName":"KHAOS","guildId":"-4YxIHwIRIG__EcWZ1F3Ew","allianceName":"","allianceId":""},"NPyUrWIgQ8CSA7VdDR7gBg":{"id":"NPyUrWIgQ8CSA7VdDR7gBg","name":"FuS","kills":0,"deaths":0,"killFame":3549,"guildName":"Exertion","guildId":"oA6UBphoR-2RP-AyCWp-uQ","allianceName":"Woke","allianceId":"yuZIjueQSzqUfPBfgEfV6Q"},"TbM4RLxeQcKKopcaWo3yJw":{"id":"TbM4RLxeQcKKopcaWo3yJw","name":"Bry","kills":0,"deaths":2,"killFame":0,"guildName":"Organized Chaos","guildId":"QGxZteaZQSOq6qW5zw-WHw","allianceName":"GEAR","allianceId":"9NGgBOv_R4O5K09RCyMUjw"},"ksmwur8ITi6Z6Xd8TnLTrg":{"id":"ksmwur8ITi6Z6Xd8TnLTrg","name":"Master14","kills":3,"deaths":2,"killFame":0,"guildName":"","guildId":"","allianceN

SyntaxError: Unexpected end of JSON input
    at Object.parse (native)
    at Request.request [as _callback] (/opt/albion/albion-guildbot/lib/AlbionApi.js:21:26)
    at Request.self.callback (/opt/albion/albion-guildbot/node_modules/request/request.js:186:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/opt/albion/albion-guildbot/node_modules/request/request.js:1163:10)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/opt/albion/albion-guildbot/node_modules/request/request.js:1085:12)
    at IncomingMessage.g (events.js:292:16)
```

```
info: Checking killboard...
undefined:1
[{"numberOfParticipants":1,"groupMemberCount":1,"EventId":10612085,"TimeStamp":"2017-11-09T11:02:53.111922500Z","Version":4,"Killer":{"AverageItemPower":971.516663,"Equipment":{"MainHand":{"Type":"T5_MAIN_RAPIER_MORGANA","Count":1,"Quality":2,"ActiveSpells":["SUNDERARMOR2","RAPIERSTAB","GROUNDDASH"],"PassiveSpells":["PASSIVE_BLEEDCHANCE"]},"OffHand":{"Type":"T6_OFF_SHIELD@1","Count":1,"Quality":2,"ActiveSpells":[],"PassiveSpells":[]},"Head":{"Type":"T6_HEAD_GATHERER_ORE","Count":1,"Quality":2,"ActiveSpells":["SELF_CLEANSE"],"PassiveSpells":["PASSIVE_HEAD_YIELD_ORE_T6"]},"Armor":{"Type":"T6_ARMOR_GATHERER_ORE","Count":1,"Quality":1,"ActiveSpells":["AMBUSH"],"PassiveSpells":["PASSIVE_YIELD_ORE_T6"]},"Shoes":{"Type":"T6_SHOES_GATHERER_ORE","Count":1,"Quality":2,"ActiveSpells":["WANDERLUST"],"PassiveSpells":["PASSIVE_SHOES_YIELD_ORE_T6"]},"Bag":{"Type":"T7_BAG","Count":1,"Quality":1,"ActiveSpells":[],"PassiveSpells":["PASSIVE_MAXLOAD"]},"Cape":{"Type":"T6_BACKPACK_GATHERER_ORE","Count":1,"Quality":1

SyntaxError: Unexpected token A in JSON at position 16367
    at Object.parse (native)
    at Request.request [as _callback] (/opt/albion/albion-guildbot/lib/AlbionApi.js:21:26)
    at Request.self.callback (/opt/albion/albion-guildbot/node_modules/request/request.js:186:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/opt/albion/albion-guildbot/node_modules/request/request.js:1163:10)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/opt/albion/albion-guildbot/node_modules/request/request.js:1085:12)
    at IncomingMessage.g (events.js:292:16)
```


