### PR TITLE
Fix lastEventId storage logic and events sort order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,14 @@ function checkKillboard() {
   Albion.getEvents({ limit: 51, offset: 0 }).then(events => {
     if (!events) { return; }
 
+    // resort events to ascending EventId order
+    events.sort(function(a, b) {
+      return a.EventId - b.EventId;
+    });
+
     events.filter(event => event.EventId > lastEventId).forEach(event => {
+      lastEventId = event.EventId;
+
       const isFriendlyKill = config.guild.guilds.indexOf(event.Killer.GuildName) !== -1;
       const isFriendlyDeath = config.guild.guilds.indexOf(event.Victim.GuildName) !== -1;
 
@@ -194,13 +201,9 @@ function checkKillboard() {
         return;
       }
 
-      if (event.EventId > lastEventId) {
-        lastEventId = event.EventId;
-        db.set('recents.eventId', lastEventId).write();
-      }
-
       sendKillReport(event);
     });
+    db.set('recents.eventId', lastEventId).write();
   });
 }
 


### PR DESCRIPTION
I wonder that `eventId` in `.db.json` is always `0` ...

To fix that I changed the sorting of the event object to ascending eventId order. So we can goto the array in correct time depending and of course eventId order (rarely times events posted in wrong time order). After one run the last eventId is also saved now :)

<img width="492" alt="bildschirmfoto 2017-11-10 um 03 48 07" src="https://user-images.githubusercontent.com/1748428/32640726-567db61a-c5ca-11e7-8930-149fffc9463f.png">

Just seen ... last death was sadly mine :-/